### PR TITLE
Bug Fix for iOS 12 missed background touches

### DIFF
--- a/Keyboard/KeyboardViewController.swift
+++ b/Keyboard/KeyboardViewController.swift
@@ -469,6 +469,19 @@ class KeyboardViewController: UIInputViewController {
         
         self.bannerView?.darkMode = appearanceIsDark
         self.settingsView?.darkMode = appearanceIsDark
+        //Fix for iOS12 update bugs where touches on the forwarding view are not being handled properly
+        //Fix just updates the background color of the forwarding view to blend in with the keyboard background view, 
+        //so that it can respond to touches
+        if #available(iOSApplicationExtension 10.0, *){
+            if(!appearanceIsDark){
+                self.forwardingView?.backgroundColor = UIColor(displayP3Red: (203/255), green: (206/255), blue: (226/255), alpha: 0.1)
+            }else{
+                self.forwardingView?.backgroundColor = UIColor(displayP3Red: (42/255), green: (43/255), blue: (53/255), alpha: 0.1)
+            }
+
+        } else {
+            // Fallback on earlier versions
+        }
     }
     
     func highlightKey(_ sender: KeyboardKey) {


### PR DESCRIPTION
Background color of forwardingView is being adjusted to blend in with the background color provided by OS so that it can handle touch events. Recent iOS updates have shown to discard the transparent view to be considered for touch handling callbacks.